### PR TITLE
Update Boolean For Correct Logging

### DIFF
--- a/src/main/java/hudson/plugins/tmpcleaner/TmpCleanTask.java
+++ b/src/main/java/hudson/plugins/tmpcleaner/TmpCleanTask.java
@@ -128,7 +128,7 @@ public class TmpCleanTask extends MasterToSlaveCallable<Void, IOException> {
     }
 
     private void delete(File child) {
-        if (child.delete()) {
+        if (!child.delete()) {
             LOGGER.info("Deletion failed: " + child);
         }
     }


### PR DESCRIPTION
- I was seeing "Deletion failed: ..." when it was actually successful
- Boolean needs to be inverted in order for it to log correctly